### PR TITLE
[D25-20] 알람 SSE 구현, 회원 조회 API memberId 값 추가

### DIFF
--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/Like/entity/ArtworkLike.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/Like/entity/ArtworkLike.java
@@ -19,11 +19,11 @@ public class ArtworkLike extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long artworkLikeId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTWORK_ID")
     private Artwork artwork;
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/controller/AlarmController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/controller/AlarmController.java
@@ -5,14 +5,12 @@ import com.codestates.mainproject.oneyearfourcut.global.config.auth.LoginMember;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/members/me/alarms")
@@ -31,12 +29,5 @@ public class AlarmController {
     @GetMapping("/read")
     public ResponseEntity<Object> checkReadAlarm(@LoginMember Long memberId){
         return new ResponseEntity<>(alarmService.checkReadAlarm(memberId), HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribe(@LoginMember Long memberId) {
-        SseEmitter sseEmitter = alarmService.subscribe(memberId);
-
-        return ResponseEntity.ok(sseEmitter);
     }
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/controller/AlarmController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/controller/AlarmController.java
@@ -1,19 +1,18 @@
 package com.codestates.mainproject.oneyearfourcut.domain.alarm.controller;
 
-import com.codestates.mainproject.oneyearfourcut.domain.alarm.dto.AlarmResponseDto;
 import com.codestates.mainproject.oneyearfourcut.domain.alarm.service.AlarmService;
 import com.codestates.mainproject.oneyearfourcut.global.config.auth.LoginMember;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/members/me/alarms")
@@ -22,14 +21,22 @@ import java.util.List;
 @AllArgsConstructor
 public class AlarmController {
     private final AlarmService alarmService;
+
     @GetMapping
     public ResponseEntity<Object> getAlarmListFiltered(@RequestParam String filter, @RequestParam int page,
-                                                       @LoginMember Long memberId){
+                                                       @LoginMember Long memberId) {
         return new ResponseEntity<>(alarmService.getAlarmPagesByFilter(filter, page, memberId), HttpStatus.OK);
     }
+
     @GetMapping("/read")
     public ResponseEntity<Object> checkReadAlarm(@LoginMember Long memberId){
         return new ResponseEntity<>(alarmService.checkReadAlarm(memberId), HttpStatus.OK);
     }
 
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(@LoginMember Long memberId) {
+        SseEmitter sseEmitter = alarmService.subscribe(memberId);
+
+        return ResponseEntity.ok(sseEmitter);
+    }
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
@@ -4,7 +4,6 @@ import com.codestates.mainproject.oneyearfourcut.domain.alarm.service.AlarmServi
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
@@ -1,6 +1,7 @@
 package com.codestates.mainproject.oneyearfourcut.domain.alarm.event;
 
 import com.codestates.mainproject.oneyearfourcut.domain.alarm.service.AlarmService;
+import com.codestates.mainproject.oneyearfourcut.domain.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -9,10 +10,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AlarmEventListener {
     private final AlarmService alarmService;
+    private final SseService sseService;
 
     @EventListener
     public void handleAlarmEvent(AlarmEvent event) {
         alarmService.createAlarm(event.getReceiverId(), event.getSenderId(), event.getAlarmType(), event.getGalleryId(), event.getArtworkId());
-        alarmService.send(event.getReceiverId());
+        sseService.send(event.getReceiverId());
     }
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
@@ -4,14 +4,16 @@ import com.codestates.mainproject.oneyearfourcut.domain.alarm.service.AlarmServi
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class AlarmEventListener {
     private final AlarmService alarmService;
 
-    @EventListener
+    @TransactionalEventListener
     public void handleAlarmEvent(AlarmEvent event) {
         alarmService.createAlarm(event.getReceiverId(), event.getSenderId(), event.getAlarmType(), event.getGalleryId(), event.getArtworkId());
+        alarmService.send(event.getReceiverId());
     }
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/event/AlarmEventListener.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class AlarmEventListener {
     private final AlarmService alarmService;
 
-    @TransactionalEventListener
+    @EventListener
     public void handleAlarmEvent(AlarmEvent event) {
         alarmService.createAlarm(event.getReceiverId(), event.getSenderId(), event.getAlarmType(), event.getGalleryId(), event.getArtworkId());
         alarmService.send(event.getReceiverId());

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
@@ -14,7 +14,13 @@ public class SseEmitterRepository {
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        SseEmitter saved = emitters.get(emitterId);
+        if (saved != null) {
+            saved.complete();
+            log.info("emitter completed!!");
+        }
         emitters.put(emitterId, sseEmitter);
+
         log.info("new emitter added: {}", emitters);
         log.info("emitter list size: {}", emitters.size());
 
@@ -24,6 +30,10 @@ public class SseEmitterRepository {
     public void deleteById(String emitterId) {
         emitters.remove(emitterId);
         log.info("emitter deleted: {}", emitterId);
+    }
+
+    public SseEmitter findById(Long memberId) {
+        return emitters.get(String.valueOf(memberId));
     }
 
     public Map<String, SseEmitter> findAllById(Long memberId) {

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
@@ -1,0 +1,34 @@
+package com.codestates.mainproject.oneyearfourcut.domain.alarm.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class SseEmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        log.info("new emitter added: {}", emitters);
+        log.info("emitter list size: {}", emitters.size());
+
+        return sseEmitter;
+    }
+
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+        log.info("emitter deleted: {}", emitterId);
+    }
+
+    public Map<String, SseEmitter> findAllById(Long memberId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(String.valueOf(memberId)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
@@ -14,9 +14,8 @@ public class SseEmitterRepository {
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
-        log.info("=============emitter 생성=============");
+        log.info("=============emitter create : {}=============", sseEmitter);
         emitters.put(emitterId, sseEmitter);
-        log.info("new emitter added: {}", sseEmitter);
         log.info("emitter list size: {}", emitters.size());
 
         return sseEmitter;

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/repository/SseEmitterRepository.java
@@ -8,20 +8,15 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-@Component
 @Slf4j
+@Component
 public class SseEmitterRepository {
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
-        SseEmitter saved = emitters.get(emitterId);
-        if (saved != null) {
-            saved.complete();
-            log.info("emitter completed!!");
-        }
+        log.info("=============emitter 생성=============");
         emitters.put(emitterId, sseEmitter);
-
-        log.info("new emitter added: {}", emitters);
+        log.info("new emitter added: {}", sseEmitter);
         log.info("emitter list size: {}", emitters.size());
 
         return sseEmitter;

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
@@ -123,7 +123,9 @@ public class AlarmService {
 //                (key, emitter) -> sendAlarm(emitter, memberId, key, true)
 //        );
         SseEmitter emitter = sseEmitterRepository.findById(memberId);
-        sendAlarm(emitter, memberId, String.valueOf(memberId), true);
+        if (emitter != null) {
+            sendAlarm(emitter, memberId, String.valueOf(memberId), true);
+        }
     }
 
     private void sendAlarm(SseEmitter emitter, Long memberId, String emitterId, Boolean readExist) {

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
@@ -106,11 +106,11 @@ public class AlarmService {
         SseEmitter emitter = sseEmitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
         //만료시 삭제
         emitter.onCompletion(() -> {
-            log.info("=============종료로 인한 삭제=============");
+            log.info("=============onCompletion Delete=============");
             sseEmitterRepository.deleteById(emitterId);
         });
         emitter.onTimeout(() -> {
-            log.info("=============타임아웃으로 인한 삭제=============");
+            log.info("=============onTimeout Delete=============");
             sseEmitterRepository.deleteById(emitterId);
         });
 
@@ -137,9 +137,9 @@ public class AlarmService {
                     .id(String.valueOf(memberId))
                     .name("newAlarms")
                     .data(readExist));
-            log.info("========{} 에게 알림 발송========", emitterId);
+            log.info("========{} Alarm Success!========", emitterId);
         }catch (IOException e) {
-            log.info("========{} 에게 전송실패=========", emitterId);
+            log.info("========{} Alarm Error=========", emitterId);
             sseEmitterRepository.deleteById(emitterId);
         }
     }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
@@ -36,7 +36,7 @@ public class AlarmService {
     private final AlarmRepository alarmRepository;
     private final SseEmitterRepository sseEmitterRepository;
 
-    private static final Long DEFAULT_TIMEOUT = 1000L * 60 * 10;
+    private static final Long DEFAULT_TIMEOUT = 1000L * 45;
 
     public List<AlarmResponseDto> getAlarmPagesByFilter(String filter, int page, Long memberId) {
         Member member = memberService.findMember(memberId);

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/service/AlarmService.java
@@ -63,7 +63,7 @@ public class AlarmService {
     }
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AlarmReadCheckResponseDto checkReadAlarm(Long memberId) {
         Boolean alarmExist = alarmRepository.existsByMember_MemberIdAndReadCheck(memberId, Boolean.FALSE);
         if (alarmExist) {
@@ -71,7 +71,6 @@ public class AlarmService {
         } else return AlarmReadCheckResponseDto.builder().readAlarmExist(Boolean.FALSE).message("현재 알림이 없습니다.").build();
     }
 
-    @Transactional
     private Page<Alarm> findAlarmPagesByFilter(String filter, Long memberId, int page) {
         PageRequest pr = PageRequest.of(page - 1, 7);
         Page<Alarm> alarmPage;
@@ -116,7 +115,7 @@ public class AlarmService {
         Map<String, SseEmitter> map = sseEmitterRepository.findAllById(memberId);
 
         map.forEach(
-                (key, emitter) -> sendAlarm(emitter, memberId, key, false)
+                (key, emitter) -> sendAlarm(emitter, memberId, key, true)
         );
     }
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/comment/entity/Comment.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/comment/entity/Comment.java
@@ -29,16 +29,16 @@ public class Comment extends Auditable {
     @Column(length = 30, nullable = false)
     private String content; // 댓글 내용
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member; // 작성자 회원 id
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "gallery_id")
     private Gallery gallery;  //작품이 아닌 전시관 전체 댓글일때
 
     // Artwork 연관관계 매핑 추가 (단방향)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "artwork_id")
     private Artwork artwork;
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/comment/entity/Reply.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/comment/entity/Reply.java
@@ -21,11 +21,11 @@ public class Reply extends Auditable {
     @Column(length = 30, nullable = false) // nullable = false 추가해도 될까요?
     private String content; // 댓글 내용
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment; // 댓글 id
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member; // 작성자 회원 id
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/JWTController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/JWTController.java
@@ -10,4 +10,10 @@ public class JWTController {    //jwt test를 위한 임시 controller
     public String index(Model model) {
         return "receive-token";
     }
+
+    @RequestMapping("/sse")
+    public String sse() {
+        return "sse";
+    }
+
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/dto/MemberResponseDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/dto/MemberResponseDto.java
@@ -9,4 +9,5 @@ public class MemberResponseDto {
     private String nickname;
     private String profile;
     private Long galleryId;
+    private Long memberId;
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
@@ -106,6 +106,6 @@ public class Member extends Auditable {
     @OneToMany(mappedBy = "member")
     private List<Alarm> alarmList = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "member")
-    private RefreshToken refreshToken;
+//    @OneToOne(fetch = FetchType.LAZY, mappedBy = "member")
+//    private RefreshToken refreshToken;
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
@@ -106,6 +106,6 @@ public class Member extends Auditable {
     @OneToMany(mappedBy = "member")
     private List<Alarm> alarmList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member")
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "member")
     private RefreshToken refreshToken;
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
@@ -9,7 +9,6 @@ import com.codestates.mainproject.oneyearfourcut.domain.gallery.entity.Gallery;
 import com.codestates.mainproject.oneyearfourcut.domain.gallery.entity.GalleryStatus;
 import com.codestates.mainproject.oneyearfourcut.domain.member.dto.MemberResponseDto;
 import com.codestates.mainproject.oneyearfourcut.global.auditable.Auditable;
-import com.codestates.mainproject.oneyearfourcut.domain.refreshToken.entity.RefreshToken;
 import lombok.*;
 
 import javax.persistence.*;
@@ -82,6 +81,7 @@ public class Member extends Auditable {
         return MemberResponseDto.builder()
                 .nickname(this.nickname)
                 .profile(this.profile)
+                .memberId(this.memberId)
                 .galleryId(galleryId)
                 .build();
     }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/refreshToken/entity/RefreshToken.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/refreshToken/entity/RefreshToken.java
@@ -18,7 +18,7 @@ public class RefreshToken extends Auditable {
 
     private String token;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/controller/SseController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/controller/SseController.java
@@ -1,0 +1,24 @@
+package com.codestates.mainproject.oneyearfourcut.domain.sse.controller;
+
+
+import com.codestates.mainproject.oneyearfourcut.domain.sse.service.SseService;
+import com.codestates.mainproject.oneyearfourcut.global.config.auth.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RestController
+public class SseController {
+    private final SseService sseService;
+
+    @GetMapping(value = "/members/me/alarms/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> alarmSubscribe(@LoginMember Long memberId) {
+        SseEmitter sseEmitter = sseService.alarmSubscribe(memberId);
+
+        return ResponseEntity.ok(sseEmitter);
+    }
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/repository/SseEmitterRepository.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/repository/SseEmitterRepository.java
@@ -1,4 +1,4 @@
-package com.codestates.mainproject.oneyearfourcut.domain.alarm.repository;
+package com.codestates.mainproject.oneyearfourcut.domain.sse.repository;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/service/SseService.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/sse/service/SseService.java
@@ -1,0 +1,65 @@
+package com.codestates.mainproject.oneyearfourcut.domain.sse.service;
+
+import com.codestates.mainproject.oneyearfourcut.domain.alarm.repository.AlarmRepository;
+import com.codestates.mainproject.oneyearfourcut.domain.sse.repository.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseService {
+    private final SseEmitterRepository sseEmitterRepository;
+    private final AlarmRepository alarmRepository;
+    private static final Long DEFAULT_TIMEOUT = 1000L * 45;
+
+    public SseEmitter alarmSubscribe(Long memberId) {
+        String emitterId = memberId + "_" + System.currentTimeMillis();
+
+
+        SseEmitter emitter = sseEmitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+        //만료시 삭제
+        emitter.onCompletion(() -> {
+            log.info("=============onCompletion Delete=============");
+            sseEmitterRepository.deleteById(emitterId);
+        });
+        emitter.onTimeout(() -> {
+            log.info("=============onTimeout Delete=============");
+            sseEmitterRepository.deleteById(emitterId);
+        });
+
+
+        Boolean readAlarmExist = alarmRepository.existsByMember_MemberIdAndReadCheck(memberId, Boolean.FALSE);
+        sendAlarm(emitter, memberId, emitterId, readAlarmExist);
+
+        return emitter;
+    }
+
+    public void send(Long memberId) { //해당 회원의 emitter에 모두 알림 보내기
+        Map<String, SseEmitter> map = sseEmitterRepository.findAllById(memberId);
+
+        map.forEach(
+                (key, emitter) -> {
+                    sendAlarm(emitter, memberId, key, true);
+                }
+        );
+    }
+
+    private void sendAlarm(SseEmitter emitter, Long memberId, String emitterId, Boolean readExist) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(String.valueOf(memberId))
+//                    .name("newAlarms")
+                    .data(readExist));
+            log.info("========{} Alarm Success!========", emitterId);
+        }catch (IOException e) {
+            log.info("========{} Alarm Error=========", emitterId);
+            sseEmitterRepository.deleteById(emitterId);
+        }
+    }
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
@@ -60,6 +60,8 @@ public class SecurityConfig {
                                 .antMatchers(HttpMethod.GET, "/galleries/**").permitAll()
                                 .antMatchers(HttpMethod.GET, "/").permitAll()
                                 .antMatchers(HttpMethod.GET, "/receive-token").permitAll()
+//                                .antMatchers(HttpMethod.GET, "/sse").permitAll()
+//                                .antMatchers(HttpMethod.GET, "/members/me/alarms/connect").permitAll()
                                 .antMatchers(HttpMethod.GET, "/docs/index.html").permitAll()
                                 .antMatchers(HttpMethod.GET, "/auth/refresh").permitAll()
                                 .antMatchers("/h2/**").permitAll()

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
@@ -65,9 +65,6 @@ public class SecurityConfig {
                                 .antMatchers(HttpMethod.GET, "/docs/index.html").permitAll()
                                 .antMatchers(HttpMethod.GET, "/auth/refresh").permitAll()
                                 .antMatchers("/h2/**").permitAll()
-//                        .antMatchers("/members/**").hasRole("USER")
-//                        .antMatchers("/galleries/**").hasRole("USER")
-//                        .antMatchers(HttpMethod.DELETE, "/galleries/**").hasRole("USER")
                                 .anyRequest().hasRole("USER")
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     hikari:
-      maximum-pool-size: 50 #커넥션 풀 갯수 설정
+#      maximum-pool-size: 50 #커넥션 풀 갯수 설정
   profiles:
     include: oauth
   jpa:

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -16,3 +16,7 @@ spring:
     multipart:
       maxFileSize: 10MB
       maxRequestSize: 10MB
+
+logging:
+  level:
+    com.zaxxer.hikari.pool.HikariPool: debug

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -9,6 +9,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        format_sql: true # 쿼리를 가독성있게 바꿔줌
   session:
     store-type: jdbc
   # 이미지 파일 용량 제한 수정
@@ -20,3 +21,8 @@ spring:
 logging:
   level:
     com.zaxxer.hikari.pool.HikariPool: debug
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -1,7 +1,11 @@
 spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 50 #커넥션 풀 갯수 설정
   profiles:
     include: oauth
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -5,7 +5,7 @@ spring:
   profiles:
     include: oauth
   jpa:
-    open-in-view: false
+#    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     hikari:
-#      maximum-pool-size: 50 #커넥션 풀 갯수 설정
+      maximum-pool-size: 50 #커넥션 풀 갯수 설정
   profiles:
     include: oauth
   jpa:

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     url: jdbc:h2:mem:test #;MODE=MySQL #- mysql문법으로 변경하는 설버
     driver-class-name: org.h2.Driver
   jpa:
-    open-in-view: false
+#    open-in-view: false
     hibernate:
       ddl-auto: create  # 스키마 자동 생성
     properties:

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     properties:
       hibernate:
 #        dialect: org.hibernate.dialect.MySQL5InnoDBDialect #- mysql문법으로 변경하는 설정
-        format_sql: false # 쿼리를 가독성있게 바꿔줌
+        format_sql: true # 쿼리를 가독성있게 바꿔줌
     show-sql: true      # SQL 쿼리 출력
     defer-datasource-initialization: true
   profiles:
@@ -42,3 +42,10 @@ server:
 #logging:
 #  level:
 #    com.zaxxer.hikari.pool.HikariPool: debug
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -38,14 +38,12 @@ server:
   servlet:
     encoding:
       charset: UTF-8
-# 커넥션 풀 로그
-#logging:
-#  level:
-#    com.zaxxer.hikari.pool.HikariPool: debug
+
 logging:
   level:
+    com.zaxxer.hikari.pool.HikariPool: debug # 커넥션 풀 로그
     org:
       hibernate:
         type:
           descriptor:
-            sql: trace
+            sql: trace # sql에 들어가는 값 로그

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -1,26 +1,21 @@
-server:
-  servlet:
-    encoding:
-      charset: UTF-8
-      
 spring:
   http:
     encoding:
       charset: UTF-8
       enabled: true
       force: true
-
   h2:
     console:
       enabled: true
       path: /h2
-
   datasource:
+    hikari:
+      maximum-pool-size: 50 #커넥션 풀 갯수 설정
     sql-script-encoding: UTF-8
     url: jdbc:h2:mem:test #;MODE=MySQL #- mysql문법으로 변경하는 설버
     driver-class-name: org.h2.Driver
-
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: create  # 스키마 자동 생성
     properties:
@@ -34,9 +29,12 @@ spring:
   sql:
     init:
       data-locations: classpath*:db/data.sql
-
   # 이미지 파일 용량 제한 수정
   servlet:
     multipart:
       maxFileSize: 10MB
       maxRequestSize: 10MB
+server:
+  servlet:
+    encoding:
+      charset: UTF-8

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -38,3 +38,7 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+# 커넥션 풀 로그
+#logging:
+#  level:
+#    com.zaxxer.hikari.pool.HikariPool: debug

--- a/server/oneyearfourcut/src/main/resources/static/docs/index.html
+++ b/server/oneyearfourcut/src/main/resources/static/docs/index.html
@@ -564,12 +564,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 88
+Content-Length: 106
 
 {
   "nickname" : "홍길동",
   "profile" : "http://testprofile",
-  "galleryId" : null
+  "galleryId" : null,
+  "memberId" : 1
 }</code></pre>
 </div>
 </div>
@@ -592,6 +593,11 @@ Content-Length: 88
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별자</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>profile</code></p></td>
@@ -1001,7 +1007,7 @@ Content-Length: 138
   "galleryId" : 1,
   "title" : "홍길동의 전시회",
   "content" : "안녕하세요",
-  "createdAt" : "2022-12-06T20:51:25.391096"
+  "createdAt" : "2022-12-29T17:21:36.811871"
 }</code></pre>
 </div>
 </div>
@@ -1092,13 +1098,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 138
+Content-Length: 137
 
 {
   "galleryId" : 1,
   "title" : "홍길동의 전시회",
   "content" : "안녕하세요",
-  "createdAt" : "2022-12-06T20:51:25.415662"
+  "createdAt" : "2022-12-29T17:21:36.82294"
 }</code></pre>
 </div>
 </div>
@@ -2224,10 +2230,10 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.eNdz4456sdd_SrC6ySuEyR2g0232N2TCNDvO4pnxmNHFZvp3AP8wborIuk4thCxw' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json' \
     -d '{
-  "content" : "댓글입니다"
+  "content" : "텍스트"
 }'</code></pre>
 </div>
 </div>
@@ -2236,13 +2242,13 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.eNdz4456sdd_SrC6ySuEyR2g0232N2TCNDvO4pnxmNHFZvp3AP8wborIuk4thCxw
+Authorization: Bearer (AccessToken)
 Accept: application/json
-Content-Length: 35
+Content-Length: 29
 Host: localhost:8080
 
 {
-  "content" : "댓글입니다"
+  "content" : "텍스트"
 }</code></pre>
 </div>
 </div>
@@ -2288,27 +2294,24 @@ Host: localhost:8080
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 285
+X-Frame-Options: DENY
+Content-Length: 276
 
 {
   "galleryId" : 1,
   "commentList" : {
     "commentId" : 1,
-    "createdAt" : "2022-11-25T11:09:24.94",
-    "modifiedAt" : "2022-11-25T11:09:24.94",
-    "memberId" : 14,
-    "nickname" : "test1",
-    "content" : "댓글입니다",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 1,
+    "nickname" : "사용자",
+    "content" : "텍스트",
     "artworkId" : null,
     "imagePath" : null
   }
@@ -2323,10 +2326,10 @@ Content-Length: 285
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/artworks/1/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.BGxRjlGl7cLFNaKchMB73c2SbLZODGa34HSqdJCDZYxritQ1Wv3-QgdoNnNGnM-F' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json' \
     -d '{
-  "content" : "댓글입니다"
+  "content" : "텍스트"
 }'</code></pre>
 </div>
 </div>
@@ -2335,13 +2338,13 @@ Content-Length: 285
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/1/artworks/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.BGxRjlGl7cLFNaKchMB73c2SbLZODGa34HSqdJCDZYxritQ1Wv3-QgdoNnNGnM-F
+Authorization: Bearer (AccessToken)
 Accept: application/json
-Content-Length: 35
+Content-Length: 29
 Host: localhost:8080
 
 {
-  "content" : "댓글입니다"
+  "content" : "텍스트"
 }</code></pre>
 </div>
 </div>
@@ -2391,28 +2394,25 @@ Host: localhost:8080
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 256
+X-Frame-Options: DENY
+Content-Length: 247
 
 {
   "galleryId" : 1,
   "artworkId" : 1,
   "commentList" : {
     "commentId" : 1,
-    "createdAt" : "2022-11-25T11:09:24.94",
-    "modifiedAt" : "2022-11-25T11:09:24.94",
-    "memberId" : 13,
-    "nickname" : "test1",
-    "content" : "댓글입니다"
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 1,
+    "nickname" : "사용자",
+    "content" : "텍스트"
   }
 }</code></pre>
 </div>
@@ -2423,7 +2423,7 @@ Content-Length: 256
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/4/comments?page=1' -i -X GET \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/comments?page=1' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -H 'Accept: application/json'</code></pre>
 </div>
@@ -2431,7 +2431,7 @@ Content-Length: 256
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /galleries/4/comments?page=1 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /galleries/1/comments?page=1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -2479,52 +2479,58 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 915
+X-Frame-Options: DENY
+Content-Length: 1095
 
 {
-  "galleryId" : 4,
+  "galleryId" : 1,
   "commentList" : [ {
-    "commentId" : 4,
-    "createdAt" : "2022-11-14T23:41:52.764644",
-    "modifiedAt" : "2022-11-16T23:41:57.764644",
-    "memberId" : 4,
-    "nickname" : "reply",
-    "content" : "comment444",
+    "commentId" : 1,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 1,
+    "nickname" : "사용자1",
+    "content" : "댓글1",
     "artworkId" : null,
-    "imagePath" : "/test.jpg"
+    "imagePath" : null
   }, {
     "commentId" : 2,
-    "createdAt" : "2022-11-12T23:41:58.764644",
-    "modifiedAt" : "2022-11-16T23:41:57.764644",
-    "memberId" : 1,
-    "nickname" : "gallery",
-    "content" : "comment2",
-    "artworkId" : 2,
-    "imagePath" : "/test.jpg"
-  }, {
-    "commentId" : 1,
-    "createdAt" : "2022-11-11T23:41:57.764644",
-    "modifiedAt" : "2022-11-16T23:41:57.764644",
-    "memberId" : 1,
-    "nickname" : "gallery",
-    "content" : "comment1댓글대스",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 2,
+    "nickname" : "사용자2",
+    "content" : "댓글2",
     "artworkId" : 1,
-    "imagePath" : "/test.jpg"
+    "imagePath" : "artwork1.jpg"
+  }, {
+    "commentId" : 3,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 3,
+    "nickname" : "사용자3",
+    "content" : "댓글3",
+    "artworkId" : null,
+    "imagePath" : null
+  }, {
+    "commentId" : 4,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 4,
+    "nickname" : "사용자4",
+    "content" : "댓글4",
+    "artworkId" : null,
+    "imagePath" : null
   } ],
   "pageInfo" : {
     "page" : 1,
     "size" : 10,
-    "totalElements" : 3,
+    "totalElements" : 4,
     "totalPages" : 1
   }
 }</code></pre>
@@ -2536,7 +2542,7 @@ Content-Length: 915
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/6/artworks/1/comments?page=1' -i -X GET \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/artworks/1/comments?page=1' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -H 'Accept: application/json'</code></pre>
 </div>
@@ -2544,7 +2550,7 @@ Content-Length: 915
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /galleries/6/artworks/1/comments?page=1 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /galleries/1/artworks/1/comments?page=1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -2596,33 +2602,51 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 375
+X-Frame-Options: DENY
+Content-Length: 929
 
 {
-  "galleryId" : 6,
+  "galleryId" : 1,
   "artworkId" : 1,
   "commentList" : [ {
     "commentId" : 1,
-    "createdAt" : "2022-11-11T23:41:57.764644",
-    "modifiedAt" : "2022-11-16T23:41:57.764644",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
     "memberId" : 1,
-    "nickname" : "gallery",
-    "content" : "comment1댓글대스"
+    "nickname" : "사용자1",
+    "content" : "댓글1"
+  }, {
+    "commentId" : 2,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 2,
+    "nickname" : "사용자2",
+    "content" : "댓글2"
+  }, {
+    "commentId" : 3,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 3,
+    "nickname" : "사용자3",
+    "content" : "댓글3"
+  }, {
+    "commentId" : 4,
+    "createdAt" : "2022-12-29T17:21:36.050453",
+    "modifiedAt" : "2022-12-29T17:21:36.050459",
+    "memberId" : 4,
+    "nickname" : "사용자4",
+    "content" : "댓글4"
   } ],
   "pageInfo" : {
     "page" : 1,
     "size" : 10,
-    "totalElements" : 1,
+    "totalElements" : 4,
     "totalPages" : 1
   }
 }</code></pre>
@@ -2634,27 +2658,27 @@ Content-Length: 375
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/5/comments/6' -i -X PATCH \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/comments/1' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.WXoIUQVbsn8FY-ypTKcu6CTJ6bVTW0x4v_B25Dxh4ytsdcwjdxB4ZbJ4hH438Yud' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json' \
     -d '{
-  "content" : "수정댓글입니다."
+  "content" : "수정된 댓글"
 }'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/5/comments/6 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/1/comments/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgzLCJleHAiOjE2NzAzMjgwODN9.WXoIUQVbsn8FY-ypTKcu6CTJ6bVTW0x4v_B25Dxh4ytsdcwjdxB4ZbJ4hH438Yud
+Authorization: Bearer (AccessToken)
 Accept: application/json
-Content-Length: 42
+Content-Length: 36
 Host: localhost:8080
 
 {
-  "content" : "수정댓글입니다."
+  "content" : "수정된 댓글"
 }</code></pre>
 </div>
 </div>
@@ -2704,27 +2728,24 @@ Host: localhost:8080
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 292
+X-Frame-Options: DENY
+Content-Length: 283
 
 {
-  "galleryId" : 5,
+  "galleryId" : 1,
   "commentList" : {
-    "commentId" : 6,
-    "createdAt" : "2022-11-25T11:09:24.94",
-    "modifiedAt" : "2022-11-25T11:09:24.94",
-    "memberId" : 11,
-    "nickname" : "test1",
-    "content" : "수정댓글입니다.",
+    "commentId" : 1,
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25",
+    "memberId" : 1,
+    "nickname" : "사용자",
+    "content" : "수정된 댓글",
     "artworkId" : null,
     "imagePath" : null
   }
@@ -2737,18 +2758,18 @@ Content-Length: 292
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/3/comments/5' -i -X DELETE \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/comments/1' -i -X DELETE \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODMsImV4cCI6MTY3MDMyODA4M30.Y7eq2wf6SbbOU59D0AhLdzzAFQsHh0GSom6Q5KmnGF5ebxvShVOG9X6MR8b0Qa_I' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/3/comments/5 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/1/comments/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODMsImV4cCI6MTY3MDMyODA4M30.Y7eq2wf6SbbOU59D0AhLdzzAFQsHh0GSom6Q5KmnGF5ebxvShVOG9X6MR8b0Qa_I
+Authorization: Bearer (AccessToken)
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -2799,15 +2820,12 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 204 No Content
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN</code></pre>
+X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <hr>
@@ -2824,10 +2842,10 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/1/replies' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDg0LCJleHAiOjE2NzAzMjgwODR9.E9AQbB8UkF-dpA5cNrtVBEBvOYNvp9ZnqbFiIKXqOfs3ogPFkYIksHVYBRHHvuhW' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json' \
     -d '{
-  "content" : "답글입니다"
+  "content" : "대댓글"
 }'</code></pre>
 </div>
 </div>
@@ -2836,13 +2854,13 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/comments/1/replies HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDg0LCJleHAiOjE2NzAzMjgwODR9.E9AQbB8UkF-dpA5cNrtVBEBvOYNvp9ZnqbFiIKXqOfs3ogPFkYIksHVYBRHHvuhW
+Authorization: Bearer (AccessToken)
 Accept: application/json
-Content-Length: 35
+Content-Length: 29
 Host: localhost:8080
 
 {
-  "content" : "답글입니다"
+  "content" : "대댓글"
 }</code></pre>
 </div>
 </div>
@@ -2888,27 +2906,24 @@ Host: localhost:8080
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 233
+X-Frame-Options: DENY
+Content-Length: 224
 
 {
   "commentId" : 1,
   "replyList" : {
     "replyId" : 1,
-    "memberId" : 10,
-    "nickname" : "test1",
-    "content" : "답글입니다",
-    "createdAt" : "2022-11-25T11:09:24.94",
-    "modifiedAt" : "2022-11-25T11:09:24.94"
+    "memberId" : 1,
+    "nickname" : "작성자",
+    "content" : "대댓글",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25"
   }
 }</code></pre>
 </div>
@@ -2956,27 +2971,38 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 187
+X-Frame-Options: DENY
+Content-Length: 608
 
 {
   "commentId" : 1,
   "replyList" : [ {
-    "replyId" : 4,
-    "memberId" : 11,
-    "nickname" : "kang",
-    "content" : "답글",
-    "createdAt" : null,
-    "modifiedAt" : null
+    "replyId" : 1,
+    "memberId" : 1,
+    "nickname" : "작성자1",
+    "content" : "대댓글1",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25"
+  }, {
+    "replyId" : 2,
+    "memberId" : 2,
+    "nickname" : "작성자2",
+    "content" : "대댓글2",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25"
+  }, {
+    "replyId" : 3,
+    "memberId" : 3,
+    "nickname" : "작성자3",
+    "content" : "대댓글3",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25"
   } ]
 }</code></pre>
 </div>
@@ -2987,27 +3013,27 @@ Content-Length: 187
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/4/replies/1' -i -X PATCH \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/1/replies/1' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDg0LCJleHAiOjE2NzAzMjgwODR9.Dq3FeKRJp2HzO1he9U5hVroHx8mFS2xY0EHyObZmUeUnzs91ro_wd2jaxg9cnDTW' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json' \
     -d '{
-  "content" : "수정대댓글입니다."
+  "content" : "수정대댓글"
 }'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/comments/4/replies/1 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/comments/1/replies/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDg0LCJleHAiOjE2NzAzMjgwODR9.Dq3FeKRJp2HzO1he9U5hVroHx8mFS2xY0EHyObZmUeUnzs91ro_wd2jaxg9cnDTW
+Authorization: Bearer (AccessToken)
 Accept: application/json
-Content-Length: 45
+Content-Length: 35
 Host: localhost:8080
 
 {
-  "content" : "수정대댓글입니다."
+  "content" : "수정대댓글"
 }</code></pre>
 </div>
 </div>
@@ -3057,27 +3083,24 @@ Host: localhost:8080
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 243
+X-Frame-Options: DENY
+Content-Length: 230
 
 {
-  "commentId" : 4,
+  "commentId" : 1,
   "replyList" : {
     "replyId" : 1,
-    "memberId" : 12,
-    "nickname" : "test1",
-    "content" : "수정대댓글입니다.",
-    "createdAt" : "2022-11-25T11:09:24.94",
-    "modifiedAt" : "2022-11-25T11:09:24.94"
+    "memberId" : 1,
+    "nickname" : "작성자",
+    "content" : "수정대댓글",
+    "createdAt" : "2022-12-25T12:25:25",
+    "modifiedAt" : "2022-12-25T12:25:25"
   }
 }</code></pre>
 </div>
@@ -3088,18 +3111,18 @@ Content-Length: 243
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/3/replies/3' -i -X DELETE \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/1/replies/1' -i -X DELETE \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODQsImV4cCI6MTY3MDMyODA4NH0.xsKkOouoVNoVDPGk3XIppuDtHt27Zj3VcWSG4QvXKsvHJvAvmMijy1Ly2tDVi_f7' \
+    -H 'Authorization: Bearer (AccessToken)' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/comments/3/replies/3 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/comments/1/replies/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODQsImV4cCI6MTY3MDMyODA4NH0.xsKkOouoVNoVDPGk3XIppuDtHt27Zj3VcWSG4QvXKsvHJvAvmMijy1Ly2tDVi_f7
+Authorization: Bearer (AccessToken)
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -3150,15 +3173,12 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 204 No Content
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-X-Frame-Options: SAMEORIGIN</code></pre>
+X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <hr>
@@ -3170,109 +3190,25 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_현재_알림_페이지_조회">7.1. 현재 알림 페이지 조회</h3>
-<div class="listingblock">
+<div class="paragraph">
 <div class="title">curl-request</div>
-<div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me/alarms?page=1&amp;filter=ALL' -i -X GET \
-    -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgxLCJleHAiOjE2NzAzMjgwODF9.Girv5RxygTIenBMQIYeh5BaXgs9Z-d_BPo6OZlj1IxA8WzcojB43tDcsBtb8gMyp' \
-    -H 'Accept: application/json'</code></pre>
+<p>Unresolved directive in index.adoc - include::/Users/phile/GitHub/OneYearFourCut/server/oneyearfourcut/build/generated-snippets/getAlarmListFiltered/curl-request.adoc[]</p>
 </div>
-</div>
-<div class="listingblock">
+<div class="paragraph">
 <div class="title">http-request</div>
-<div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /members/me/alarms?page=1&amp;filter=ALL HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJrYW5nQGdtYWlsLmNvbSIsInN1YiI6ImthbmdAZ21haWwuY29tIiwiaWF0IjoxNjcwMzI3NDgxLCJleHAiOjE2NzAzMjgwODF9.Girv5RxygTIenBMQIYeh5BaXgs9Z-d_BPo6OZlj1IxA8WzcojB43tDcsBtb8gMyp
-Accept: application/json
-Host: localhost:8080</code></pre>
+<p>Unresolved directive in index.adoc - include::/Users/phile/GitHub/OneYearFourCut/server/oneyearfourcut/build/generated-snippets/getAlarmListFiltered/http-request.adoc[]</p>
 </div>
+<div class="paragraph">
+<div class="title">request-headers</div>
+<p>Unresolved directive in index.adoc - include::/Users/phile/GitHub/OneYearFourCut/server/oneyearfourcut/build/generated-snippets/getAlarmListFiltered/request-headers.adoc[]</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 58. request-headers</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">JWT - Access Token</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 59. request-parameters</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>filter</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 기준</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 수</p></td>
-</tr>
-</tbody>
-</table>
-<div class="listingblock">
+<div class="paragraph">
+<div class="title">request-parameters</div>
+<p>Unresolved directive in index.adoc - include::/Users/phile/GitHub/OneYearFourCut/server/oneyearfourcut/build/generated-snippets/getAlarmListFiltered/request-parameters.adoc[]</p>
+</div>
+<div class="paragraph">
 <div class="title">http-response</div>
-<div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: SAMEORIGIN
-Content-Length: 641
-
-[ {
-  "alarmId" : 2,
-  "alarmType" : "POST_ARTWORK",
-  "userNickname" : "행위유저 1",
-  "createdAt" : "2022-12-06T20:51:21.549896",
-  "read" : false,
-  "artworkId" : 1,
-  "artworkTitle" : "Test 작품 입니다."
-}, {
-  "alarmId" : 3,
-  "alarmType" : "LIKE_ARTWORK",
-  "userNickname" : "행위유저 2",
-  "createdAt" : "2022-12-06T20:51:21.550616",
-  "read" : false,
-  "artworkId" : 1,
-  "artworkTitle" : "Test 작품 입니다."
-}, {
-  "alarmId" : 4,
-  "alarmType" : "COMMENT_GALLERY",
-  "userNickname" : "행위유저 3",
-  "createdAt" : "2022-12-06T20:51:21.551081",
-  "read" : true,
-  "artworkId" : null,
-  "artworkTitle" : null
-} ]</code></pre>
-</div>
+<p>Unresolved directive in index.adoc - include::/Users/phile/GitHub/OneYearFourCut/server/oneyearfourcut/build/generated-snippets/getAlarmListFiltered/http-response.adoc[]</p>
 </div>
 </div>
 <div class="sect2">
@@ -3282,7 +3218,7 @@ Content-Length: 641
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me/alarms/read' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODEsImV4cCI6MTY3MDMyODA4MX0.f-B_j0u6YJ2785cORI1kbYYtZEbvPry0fSecrwBn9JhsH_S4roGYFTVla426WTbD' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzIzMDIwOTQsImV4cCI6MTY3MjQ3NDg5NH0.GurufAhYiIfo0-zlArbsxP_tGgxLNcxRwllU4KhBuj6ZYUCV97QzNKTTdzLhVz4R' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -3291,13 +3227,13 @@ Content-Length: 641
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /members/me/alarms/read HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzAzMjc0ODEsImV4cCI6MTY3MDMyODA4MX0.f-B_j0u6YJ2785cORI1kbYYtZEbvPry0fSecrwBn9JhsH_S4roGYFTVla426WTbD
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6ImthbmdAZ21haWwuY29tIiwic3ViIjoia2FuZ0BnbWFpbC5jb20iLCJpYXQiOjE2NzIzMDIwOTQsImV4cCI6MTY3MjQ3NDg5NH0.GurufAhYiIfo0-zlArbsxP_tGgxLNcxRwllU4KhBuj6ZYUCV97QzNKTTdzLhVz4R
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 60. request-headers</caption>
+<caption class="title">Table 58. request-headers</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3344,7 +3280,7 @@ Content-Length: 78
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-12-05 15:12:41 +0900
+Last updated 2022-12-11 14:32:39 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/server/oneyearfourcut/src/main/resources/templates/index.html
+++ b/server/oneyearfourcut/src/main/resources/templates/index.html
@@ -7,5 +7,7 @@
 <body>
 <h1>OAuth2 카카오 로그인 테스트</h1>
 <a href="/oauth2/authorization/kakao"> Kakao로 로그인 </a>
+<br>
+<a href="/sse">sse</a>
 </body>
 </html>

--- a/server/oneyearfourcut/src/main/resources/templates/sse.html
+++ b/server/oneyearfourcut/src/main/resources/templates/sse.html
@@ -6,7 +6,7 @@
       const eventSource = new EventSource("/members/me/alarms/connect")
       eventSource.onmessage = event => {
         const p = document.createElement("p")
-        p.innerText = event.Data
+        p.innerText = event.data
 
         document.getElementById("messages").appendChild(p)
       }

--- a/server/oneyearfourcut/src/main/resources/templates/sse.html
+++ b/server/oneyearfourcut/src/main/resources/templates/sse.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <script>
+      const eventSource = new EventSource("/members/me/alarms/connect")
+      eventSource.onmessage = event => {
+        const p = document.createElement("p")
+        p.innerText = event.Data
+
+        document.getElementById("messages").appendChild(p)
+      }
+    </script>
+</head>
+
+<body>
+<div id="messages"></div>
+</body>
+</html>

--- a/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/AlarmServiceTest.java
+++ b/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/alarm/AlarmServiceTest.java
@@ -9,75 +9,15 @@ import com.codestates.mainproject.oneyearfourcut.domain.gallery.repository.Galle
 import com.codestates.mainproject.oneyearfourcut.domain.gallery.service.GalleryService;
 import com.codestates.mainproject.oneyearfourcut.domain.member.repository.MemberRepository;
 import com.codestates.mainproject.oneyearfourcut.domain.member.service.MemberService;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
+
+@ExtendWith(MockitoExtension.class)
 class AlarmServiceTest {
-
-    @Mock
-    private MemberService memberService;
-    @Mock
-    private ArtworkService artworkService;
-    @Mock
-    private GalleryService galleryService;
-    @Mock
-    private CommentService commentService;
-
-    @Mock
-    private GalleryRepository galleryRepository;
-
-    @Autowired
-    private AlarmRepository alarmRepository;
-    @Autowired
-    private ArtworkRepository artworkRepository;
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @InjectMocks
-    private AlarmService alarmService;
-
-
-    /*@Test
-    @DisplayName("create  alarm ")
-    void testCreateAlarm(Long locationId, Long memberId, AlarmType type) {
-        //given
-        Member member = memberRepository.save(
-                Member.builder()
-                        .nickname("홍길동")
-                        .build());
-
-        System.out.println(member.getMemberId());
-        assertThat
-
-        *//*Artwork artwork = new Artwork(locationId);
-
-            given
-
-            if(type != COMMENT_GALLERY) {
-                member = artworkRepository.findById(locationId).orElseThrow().getMember();
-                artwork = artworkRepository.findById(locationId).orElseThrow(); }
-            else { member = galleryService.findGallery(locationId).getMember();
-                artwork = null;}
-
-            assert artwork != null;
-
-            Alarm alarm = Alarm.builder()
-                    .member(member)
-                    .memberIdProducer(memberId)
-                    .alarmType(type)
-                    .artworkId(artwork.getArtworkId())
-                    .artworkTitle(artwork.getTitle())
-                    .userNickname(memberService.findMember(memberId).getNickname())
-                    .readCheck(false)
-                    .build();
-
-            alarmRepository.save(alarm);*//*
-    }
-*/
-
-
-
 
 
 }

--- a/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
+++ b/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
@@ -68,6 +68,7 @@ class MemberControllerRestDocsTest {
                     .build();
         }
     }
+
     @BeforeAll
     public static void setup() {
         //security context holder
@@ -77,16 +78,15 @@ class MemberControllerRestDocsTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(new PrincipalDto(username, id), null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
-
     private String jwt = "Bearer test1234test1234";
-    private Member member = Member.builder()
-            .nickname("홍길동")
-            .profile("http://testprofile")
-            .build();
 
     @Test
     void getMember() throws Exception {
         //given
+        Member member = new Member(1L);
+        member.updateProfile("http://testprofile");
+        member.updateNickname("홍길동");
+
         given(memberService.findMember(anyLong()))
                 .willReturn(member);
 
@@ -111,8 +111,10 @@ class MemberControllerRestDocsTest {
                         responseFields(
                                 List.of(
                                         fieldWithPath("nickname").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
                                         fieldWithPath("profile").type(JsonFieldType.STRING).description("프로필 이미지 경로"),
                                         fieldWithPath("galleryId").type(JsonFieldType.NULL).description("오픈 전시관 식별자(없으면 null, 있으면 숫자)")
+
                                 )
                         )
                 ));
@@ -121,7 +123,11 @@ class MemberControllerRestDocsTest {
     @Test
     void patchMember() throws Exception {
         //given
-        // member 등록
+        Member member = Member.builder()
+                .nickname("홍길동")
+                .profile("http://testprofile")
+                .build();
+
         given(memberService.modifyMember(anyLong(), any(MemberRequestDto.class)))
                 .willReturn(member.toMemberResponseDto());
 


### PR DESCRIPTION
1. sse을 알람 도메인에서 분리하여 구현했습니다
(서비스단에서 alarmSubscribe()를 통해 연결이 되고, sendAlarm()을 통해 데이터를 프론트에 전달하게됩니다)
2. 로그인 회원 조회 시 "memberId" 값을 응답데이터에 추가했습니다.
3. 기본값이 fetch EAGER이었던 맵핑에 (fetch = FetchType.LAZY) 옵션을 추가했습니다.
4. refresh token이 member와 1:1 양방향 맵핑 되어있는데, 이런 경우 member조회할때 refresh token도 무조건 함께 조회되어서 
refresh token -> member 단방향 맵핑으로 바꿨습니다.
5. 커넥션 풀이 기본값이 10개인데 50개로 늘리는 yml 설정을 추가했습니다.
4. 알람 도메인쪽 테스트코드는 아직 작성하지 않았습니다.